### PR TITLE
feat: allow malukenho/docheader in version 1.0 to allow symfony 6 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "friendsofphp/php-cs-fixer": "^3.0",
-        "malukenho/docheader": "^0.1.7",
+        "malukenho/docheader": "^0.1.7|1.0",
         "php": ">=7.3"
     },
     "extra": {


### PR DESCRIPTION
support.

See https://github.com/malukenho/docheader/blob/master/composer.json